### PR TITLE
Fix makefile and dependencies for raspberry pi

### DIFF
--- a/detect_sound.py
+++ b/detect_sound.py
@@ -91,7 +91,8 @@ class AudioHandler:
                 password=os.environ["DB_PASSWORD"],
                 host=os.environ["DB_HOST"],
                 port=os.environ["DB_PORT"],
-                database=os.environ["DB_NAME"]
+                database=os.environ["DB_NAME"],
+                sslmode=os.environ["DB_SSL_MODE"]
             )
             cursor = connection.cursor()
 

--- a/makefile
+++ b/makefile
@@ -10,6 +10,7 @@ export DB_HOST=
 export DB_PORT=
 export DB_NAME=
 export DB_TABLE=
+export DB_SSL_MODE=prefer
 
 ###############################################################
 # COMMANDS                                                    #
@@ -20,9 +21,9 @@ install: ## installing dependencies for ARM architectures for all x86 architectu
 
 install-arm: ## installing dependencies for ARM architectures like Raspberry Pi
 	@echo ">>> installing dependencies for ARM architectures like Raspberry Pi"
-	sudo apt install -y libatlas-base-dev. libportaudio2 llvm-9 libpq5
-	LLVM_CONFIG=llvm-config-9 pip install llvmlite
-	pip install -r requirements.txt
+	sudo apt install -y libatlas-base-dev libportaudio2 llvm-9 libpq5
+	LLVM_CONFIG=llvm-config-9 pip install llvmlite==0.33
+	LLVM_CONFIG=llvm-config-9 pip install -r requirements.txt
 
 run: ## Start listening the environment to detect coffee sound
 	@echo ">>> generating features"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-librosa==0.8.1
+librosa==0.8.0
 sounddevice==0.4.2
 psycopg2-binary==2.9.1
+numba==0.50.0


### PR DESCRIPTION
Fix the makefile and requirement files for a fresh install on a Raspberry Pi

llvmlite 0.33 is the latest version working with LLVM 9 shipped with the RPi, and libarosa + numba needs to be fixed to match this version

I also added a way to specify the ssl mode for the PG connection